### PR TITLE
Make descendant iteration breadth-first, not depth-first

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1093,9 +1093,16 @@ function generateCode(grammar: AGGrammar): string {
 
   output.push(`
     function* iterDescendants<N extends Node>(node: N): IterableIterator<DescendantsOf<N>> {
-      for (const child of iterChildren(node)) {
-        yield child
-        yield *iterDescendants(child)
+      // Perform breadth-first traversal, not depth-first
+      const queue: Node[] = [node]
+      while (true) {
+        const current = queue.shift()
+        if (current === undefined) break;  // Done
+
+        yield current as DescendantsOf<N>
+        for (const child of iterChildren(current)) {
+          queue.push(child)
+        }
       }
     }
   `)


### PR DESCRIPTION
Of course there are use cases for both, and maybe we'll need to allow both modes eventually. For now, breadth-first matched the previous implementation of `visit()`.