### PR TITLE
Add support for literal types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - **Breaking** Node unions no longer have to be written using `@MyUnion` syntax. This is
   now "just" `MyUnion`. The definition itself determines whether it's a union or a basic
   node.
+- Added support for literal types, e.g., `op: ">" | "<" | ">=" | "<="` (previously the
+  closest best thing was `op: string`).
 
 ## [0.4.0] - 2025-01-29
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following grammar definition (in a file called `ast.grammar`) describes thre
 // In ast.grammar
 
 Document {
-  version?: number
+  version?: 1 | 2
   shapes: Shape*
 }
 
@@ -67,7 +67,7 @@ export type Node = Document | Shape | Circle
 
 export type Document = {
   type: "Document"
-  version: number | null
+  version: 1 | 2 | null
   shapes: Shape[]
 }
 
@@ -94,7 +94,7 @@ export type Rect = {
 Each node will get a lowercased function to construct the associated node type.
 
 ```ts
-export function document(version: number | null, shapes: Shape[]): Document {}
+export function document(version: 1 | 2 | null, shapes: Shape[]): Document {}
 export function circle(cx: number, cy: number, r: number): Circle {}
 export function rect(x: number, y: number, width: number, height: number): Rect {}
 ```
@@ -164,7 +164,7 @@ This would produce the node types as:
 ```ts
 export type Document = {
   _kind: "Document" // 👈
-  version: number | null
+  version: 1 | 2 | null
   shapes: Shape[]
 }
 
@@ -197,7 +197,7 @@ semantic method prettify()
 semantic method check()
 
 Document {
-  version?: number
+  version?: 1 | 2
   shapes: Shape*
 }
 

--- a/src/__tests__/__snapshots__/generator.test.ts.snap
+++ b/src/__tests__/__snapshots__/generator.test.ts.snap
@@ -36,7 +36,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
           "pattern": {
             "kind": "BuiltinTS",
             "types": [
-              "string",
+              {
+                "kind": "TSNativeType",
+                "typeName": "string",
+              },
             ],
           },
         },
@@ -49,7 +52,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "string",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "string",
+                },
               ],
             },
           },
@@ -63,7 +69,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "string",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "string",
+                },
               ],
             },
           },
@@ -76,7 +85,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "string",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "string",
+                },
               ],
             },
           },
@@ -186,7 +198,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
           "pattern": {
             "kind": "BuiltinTS",
             "types": [
-              "string",
+              {
+                "kind": "TSNativeType",
+                "typeName": "string",
+              },
             ],
           },
         },
@@ -199,7 +214,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "string",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "string",
+                },
               ],
             },
           },
@@ -213,7 +231,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "string",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "string",
+                },
               ],
             },
           },
@@ -226,7 +247,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "string",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "string",
+                },
               ],
             },
           },
@@ -342,7 +366,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "number",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "number",
+                },
               ],
             },
           },
@@ -357,7 +384,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "number",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "number",
+                },
               ],
             },
           },
@@ -374,20 +404,150 @@ exports[`parsing grammars > parses a grammar 1`] = `
           "pattern": {
             "kind": "BuiltinTS",
             "types": [
-              "number",
+              {
+                "kind": "TSNativeType",
+                "typeName": "number",
+              },
             ],
+          },
+        },
+        {
+          "kind": "Field",
+          "name": "op",
+          "pattern": {
+            "kind": "BuiltinTS",
+            "types": [
+              {
+                "constant": ">",
+                "kind": "TSLiteralType",
+              },
+              {
+                "constant": "<",
+                "kind": "TSLiteralType",
+              },
+              {
+                "constant": ">=",
+                "kind": "TSLiteralType",
+              },
+              {
+                "constant": "<=",
+                "kind": "TSLiteralType",
+              },
+            ],
+          },
+        },
+        {
+          "kind": "Field",
+          "name": "version",
+          "pattern": {
+            "kind": "Optional",
+            "of": {
+              "kind": "BuiltinTS",
+              "types": [
+                {
+                  "constant": 1,
+                  "kind": "TSLiteralType",
+                },
+              ],
+            },
+          },
+        },
+        {
+          "kind": "Field",
+          "name": "bits",
+          "pattern": {
+            "kind": "List",
+            "min": 0,
+            "of": {
+              "kind": "BuiltinTS",
+              "types": [
+                {
+                  "constant": 0,
+                  "kind": "TSLiteralType",
+                },
+                {
+                  "constant": 1,
+                  "kind": "TSLiteralType",
+                },
+              ],
+            },
           },
         },
       ],
       "fieldsByName": {
+        "bits": {
+          "kind": "Field",
+          "name": "bits",
+          "pattern": {
+            "kind": "List",
+            "min": 0,
+            "of": {
+              "kind": "BuiltinTS",
+              "types": [
+                {
+                  "constant": 0,
+                  "kind": "TSLiteralType",
+                },
+                {
+                  "constant": 1,
+                  "kind": "TSLiteralType",
+                },
+              ],
+            },
+          },
+        },
+        "op": {
+          "kind": "Field",
+          "name": "op",
+          "pattern": {
+            "kind": "BuiltinTS",
+            "types": [
+              {
+                "constant": ">",
+                "kind": "TSLiteralType",
+              },
+              {
+                "constant": "<",
+                "kind": "TSLiteralType",
+              },
+              {
+                "constant": ">=",
+                "kind": "TSLiteralType",
+              },
+              {
+                "constant": "<=",
+                "kind": "TSLiteralType",
+              },
+            ],
+          },
+        },
         "s": {
           "kind": "Field",
           "name": "s",
           "pattern": {
             "kind": "BuiltinTS",
             "types": [
-              "number",
+              {
+                "kind": "TSNativeType",
+                "typeName": "number",
+              },
             ],
+          },
+        },
+        "version": {
+          "kind": "Field",
+          "name": "version",
+          "pattern": {
+            "kind": "Optional",
+            "of": {
+              "kind": "BuiltinTS",
+              "types": [
+                {
+                  "constant": 1,
+                  "kind": "TSLiteralType",
+                },
+              ],
+            },
           },
         },
       },
@@ -404,7 +564,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
           "pattern": {
             "kind": "BuiltinTS",
             "types": [
-              "string",
+              {
+                "kind": "TSNativeType",
+                "typeName": "string",
+              },
             ],
           },
         },
@@ -417,7 +580,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "string",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "string",
+                },
               ],
             },
           },
@@ -431,7 +597,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "string",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "string",
+                },
               ],
             },
           },
@@ -444,7 +613,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "string",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "string",
+                },
               ],
             },
           },
@@ -554,7 +726,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
           "pattern": {
             "kind": "BuiltinTS",
             "types": [
-              "string",
+              {
+                "kind": "TSNativeType",
+                "typeName": "string",
+              },
             ],
           },
         },
@@ -567,7 +742,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "string",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "string",
+                },
               ],
             },
           },
@@ -581,7 +759,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "string",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "string",
+                },
               ],
             },
           },
@@ -594,7 +775,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "string",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "string",
+                },
               ],
             },
           },
@@ -710,7 +894,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "number",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "number",
+                },
               ],
             },
           },
@@ -725,7 +912,10 @@ exports[`parsing grammars > parses a grammar 1`] = `
             "of": {
               "kind": "BuiltinTS",
               "types": [
-                "number",
+                {
+                  "kind": "TSNativeType",
+                  "typeName": "number",
+                },
               ],
             },
           },
@@ -742,20 +932,150 @@ exports[`parsing grammars > parses a grammar 1`] = `
           "pattern": {
             "kind": "BuiltinTS",
             "types": [
-              "number",
+              {
+                "kind": "TSNativeType",
+                "typeName": "number",
+              },
             ],
+          },
+        },
+        {
+          "kind": "Field",
+          "name": "op",
+          "pattern": {
+            "kind": "BuiltinTS",
+            "types": [
+              {
+                "constant": ">",
+                "kind": "TSLiteralType",
+              },
+              {
+                "constant": "<",
+                "kind": "TSLiteralType",
+              },
+              {
+                "constant": ">=",
+                "kind": "TSLiteralType",
+              },
+              {
+                "constant": "<=",
+                "kind": "TSLiteralType",
+              },
+            ],
+          },
+        },
+        {
+          "kind": "Field",
+          "name": "version",
+          "pattern": {
+            "kind": "Optional",
+            "of": {
+              "kind": "BuiltinTS",
+              "types": [
+                {
+                  "constant": 1,
+                  "kind": "TSLiteralType",
+                },
+              ],
+            },
+          },
+        },
+        {
+          "kind": "Field",
+          "name": "bits",
+          "pattern": {
+            "kind": "List",
+            "min": 0,
+            "of": {
+              "kind": "BuiltinTS",
+              "types": [
+                {
+                  "constant": 0,
+                  "kind": "TSLiteralType",
+                },
+                {
+                  "constant": 1,
+                  "kind": "TSLiteralType",
+                },
+              ],
+            },
           },
         },
       ],
       "fieldsByName": {
+        "bits": {
+          "kind": "Field",
+          "name": "bits",
+          "pattern": {
+            "kind": "List",
+            "min": 0,
+            "of": {
+              "kind": "BuiltinTS",
+              "types": [
+                {
+                  "constant": 0,
+                  "kind": "TSLiteralType",
+                },
+                {
+                  "constant": 1,
+                  "kind": "TSLiteralType",
+                },
+              ],
+            },
+          },
+        },
+        "op": {
+          "kind": "Field",
+          "name": "op",
+          "pattern": {
+            "kind": "BuiltinTS",
+            "types": [
+              {
+                "constant": ">",
+                "kind": "TSLiteralType",
+              },
+              {
+                "constant": "<",
+                "kind": "TSLiteralType",
+              },
+              {
+                "constant": ">=",
+                "kind": "TSLiteralType",
+              },
+              {
+                "constant": "<=",
+                "kind": "TSLiteralType",
+              },
+            ],
+          },
+        },
         "s": {
           "kind": "Field",
           "name": "s",
           "pattern": {
             "kind": "BuiltinTS",
             "types": [
-              "number",
+              {
+                "kind": "TSNativeType",
+                "typeName": "number",
+              },
             ],
+          },
+        },
+        "version": {
+          "kind": "Field",
+          "name": "version",
+          "pattern": {
+            "kind": "Optional",
+            "of": {
+              "kind": "BuiltinTS",
+              "types": [
+                {
+                  "constant": 1,
+                  "kind": "TSLiteralType",
+                },
+              ],
+            },
           },
         },
       },

--- a/src/__tests__/generator.test.ts
+++ b/src/__tests__/generator.test.ts
@@ -38,6 +38,9 @@ Pqr {
 # This is a comment
 Stu {
   s: number
+  op: ">" | "<" | ">=" | "<="
+  version?: 1
+  bits: 0 | 1 *
 }
 `)
     ).toMatchSnapshot()


### PR DESCRIPTION
Added support for literal types, e.g., `op: ">" | "<" | ">=" | "<="` (previously the closest best thing was `op: string`).